### PR TITLE
fix: cvar error in client console

### DIFF
--- a/scripting/ServerAdvertisements.sp
+++ b/scripting/ServerAdvertisements.sp
@@ -32,7 +32,6 @@ StringMap gGreetedAuthIds;
 
 public void OnPluginStart()
 {
-	CreateConVar("SA_version", PLUGIN_VERSION, "ServerAdvertisements", FCVAR_SPONLY | FCVAR_NOTIFY);
 	AutoExecConfig(true, "ServerAdvertisements");
 
 	RegAdminCmd("sm_SAr", Command_SAr, ADMFLAG_ROOT, "Message reload");


### PR DESCRIPTION
Get ride of console error: ConVarRef SA_version doesn't point to an existing ConVar